### PR TITLE
Formatting, highlight and capitalization tweaks in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The [example app](example/) shows the main features of React Native Godot in act
 
 ## Install Prerequisites
 
-During development we use [ASDF](https://asdf-vm.com/) to manage most external dependencies required for React Native development, like node, java, gradle or ruby. If you also use ASDF, just run:
+During development we use [ASDF](https://asdf-vm.com/) to manage most external dependencies required for React Native development, like Node, Java, Gradle or Ruby. If you also use ASDF, just run:
 
 ```sh
 asdf install
@@ -47,8 +47,8 @@ cd example
 ./export_godot_GodotTest2.sh ios
 ```
 
-The script is configured to look for Godot in the standard system wide installation folder on MacOS. If your Godot is installed elsewhere, or you are on Linux, just point the GODOT_EDITOR
-environment variable to your GODOT EDITOR prior to running the above scripts:
+The script is configured to look for Godot in the standard system wide installation folder on macOS. If your Godot is installed elsewhere, or you are on Linux, just point the `GODOT_EDITOR`
+environment variable to your Godot editor prior to running the above scripts:
 
 ```sh
 export GODOT_EDITOR=/path/to/godot_editor
@@ -62,7 +62,7 @@ yarn
 yarn download-prebuilt
 ```
 
-These commands will resolve all the React Native and other dependencies from NPM. The second one will download the prebuilt LibGodot release from GitHub.
+These commands will resolve all the React Native and other dependencies from npm. The second one will download the prebuilt LibGodot release from GitHub.
 
 ## Run on the iOS Simulator
 
@@ -88,7 +88,8 @@ You may use Xcode and Android Studio the same way as with any other project. Jus
 * ``ios/GodotTest.xcworkspace`` from Xcode
 * ``android`` from Android Studio
 
-Note: If you are using ASDF to manage your java and Node dependencies, you should start Android Studio from under the react-native-godot (or example) folder, so it can find these tools. For example on MacOS:
+> [!note]
+> If you are using ASDF to manage your Java and Node dependencies, you should start Android Studio from under the `react-native-godot` (or `example`) folder, so it can find these tools. For example on macOS:
 
 ```sh
 cd example
@@ -97,7 +98,7 @@ open -a "Android Studio"
 
 ## Convenience script for dependency management
 
-There is an update_deps.sh script included in the example app's folder. It will execute all the setup commands for both iOS and Android in one step, so you may start your work immediately.
+There is an `update_deps.sh` script included in the example app's folder. It will execute all the setup commands for both iOS and Android in one step, so you may start your work immediately.
 
 ```sh
 cd example
@@ -107,11 +108,11 @@ yarn ios # or yarn android
 
 # Your first React Native Godot App
 
-Born React Native Godot is distributed on NPM.
+Born React Native Godot is distributed on npm.
 
 Just follow these steps to add it to your React Native application:
 
-## Update package.json
+## Update `package.json`
 
 ```sh
 yarn add @borndotcom/react-native-godot
@@ -119,7 +120,7 @@ yarn add @borndotcom/react-native-godot
 
 ## Download the prebuilt LibGodot packages
 
-The LibGodot packages used by React Native Godot are not distributed on NPM. Instead, they are downloaded separately by issuing the following command:
+The LibGodot packages used by React Native Godot are not distributed on npm. Instead, they are downloaded separately by issuing the following command:
 
 ```sh
 yarn download-prebuilt
@@ -145,12 +146,11 @@ const App = () => {
 };
 ```
 
-If no windowName property is specified, that view is for the main window of Godot.
+If no `windowName` property is specified, that view is for the main window of Godot.
 
 ## Initialize the Godot instance
 
-We will also add Expo Filesystem module for handling file system paths from React Native
-easily.
+We will also add Expo Filesystem module for handling file system paths from React Native easily.
 
 ```sh
 yarn add expo-file-system
@@ -188,7 +188,7 @@ A couple of things to note here:
 * The usual Godot command line parameters can be passed to the initialization function.
 * It is key to use the "embedded" display driver, which is required to embed Godot into the React Native application.
 * It is possible to specify both a directory or a pack file.
-  * On Android, inside the main package the access of the pack file's contents is much slower than accessing pack files stored in the private area of the application. If the Godot app is stored inside the main package, then it should be stored as a folder of files in the asset folder. 
+  * On Android, inside the main package the access of the pack file's contents is much slower than accessing pack files stored in the private area of the application. If the Godot app is stored inside the main package, then it should be stored as a folder of files in the `asset` folder. 
   * On iOS, there is no such limitation, so we use a pack file there. 
 * In many cases the best way is to download the Godot apps at runtime, which has many advantages, including:
   * Smaller initial application size
@@ -218,7 +218,7 @@ Check out the [example app](example/) in this repository for a more elaborate ex
 
 ## Stop the Godot instance
 
-To stop a running Godot instance, call RTNGodot.destroyInstance() on the Godot thread:
+To stop a running Godot instance, call `RTNGodot.destroyInstance()` on the Godot thread:
 
 ```typescript
 function destroyGodot() {
@@ -229,11 +229,12 @@ function destroyGodot() {
 }
 ```
 
-NOTE: After stopping an instance, you can start a new one by calling RTNGodot.createInstance again. The new instance can be started with different parameters including other Godot projects.
+> [!note]
+> After stopping an instance, you can start a new one by calling `RTNGodot.createInstance` again. The new instance can be started with different parameters including other Godot projects.
 
 ## Pause the Godot instance
 
-To pause a running Godot instance, call RTNGodot.pause() on the Javascript main thread:
+To pause a running Godot instance, call `RTNGodot.pause()` on the JavaScript main thread:
 
 ```typescript
 RTNGodot.pause();
@@ -243,7 +244,7 @@ This won't shut down the running instance, just halt it's execution until furthe
 
 ## Resume the Godot instance
 
-To resume a paused Godot instance, call RTNGodot.resume() on the Javascript main thread:
+To resume a paused Godot instance, call `RTNGodot.resume()` on the JavaScript main thread:
 
 ```typescript
 RTNGodot.resume();
@@ -253,9 +254,9 @@ RTNGodot.resume();
 
 You may use the usual export functionality of Godot Engine, just make sure to export to PCK or ZIP and not the whole application.
 
-In the React Native Godot example application an ``export_godot.sh`` and an associated ``export_godot_GodotTest.sh`` script is provided, which can make the export process easier.
+In the React Native Godot example application an `export_godot.sh` and an associated `export_godot_GodotTest.sh` script is provided, which can make the export process easier.
 
-To export your project to iOS or Android, use our included export_godot.sh script with the following parameters:
+To export your project to iOS or Android, use our included `export_godot.sh` script with the following parameters:
 
 ```
 --target: Base directory where the project will be exported. Depending on the platform a pck file or a folder will be created here.
@@ -267,15 +268,15 @@ To export your project to iOS or Android, use our included export_godot.sh scrip
 
 Notes:
 * Android projects will be exported into project folders while iOS project will be exported as PCK files.
-* By default, export_godot.sh will look for an official Godot installation under the Applications folder. If your installation is somewhere else or you would like to use a custom Godot build, specify it's location in the GODOT_EDITOR environment variable.
+* By default, `export_godot.sh` will look for an official Godot installation under the Applications folder. If your installation is somewhere else or you would like to use a custom Godot build, specify it's location in the `GODOT_EDITOR` environment variable.
 
 # Godot API Usage
 
-After importing React Native Godot, you can access the Godot API through the RTNGodot class.
+After importing React Native Godot, you can access the Godot API through the `RTNGodot` class.
 
 ## Get the API entry point
 
-To access the Godot API, first call RTNGodot.API():
+To access the Godot API, first call `RTNGodot.API()`:
 
 ```typescript
 let Godot = RTNGodot.API();
@@ -384,7 +385,7 @@ function worklet() {
 
 These functions and all their external dependencies are transpiled into self contained JS bundles so they can be executed in separate JS contexts associated with separate threads. For more information on how this works, please refer to the [React Native Worklets Core documentation](https://github.com/margelo/react-native-worklets-core/blob/main/docs/USAGE.md).
 
-React Native Godot provides a helper function called ``runOnGodotThread()`` which will allow you to execute such _workletized_ JS functions on the Godot thread.
+React Native Godot provides a helper function called `runOnGodotThread()` which will allow you to execute such _workletized_ JS functions on the Godot thread.
 
 In general, this is the recommended way of interacting with the Godot Engine, as shown in our example app.
 
@@ -400,7 +401,7 @@ While it is possible to interact with the Godot Engine directly from the main Re
 
 ## Using a custom LibGodot build
 
-1. To use a custom LibGodot build, you first need to clone the [LibGodot project](https://github.com/migeran/libgodot) on the branch ``libgodot_migeran_45``, including all its submodules.
+1. To use a custom LibGodot build, you first need to clone the [LibGodot project](https://github.com/migeran/libgodot) on the branch `libgodot_migeran_45`, including all its submodules.
 
     ```sh
     git clone --recursive https://github.com/migeran/libgodot -b libgodot_migeran_45
@@ -417,7 +418,7 @@ While it is possible to interact with the Godot Engine directly from the main Re
 
     NOTE: You may comment out the unnecessary lines in the build script if you're only building for one platform.
 
-    At the end of the process, the necessary files will be produced in the ``build/prebuilt/release`` or the ``build/prebuilt/dev`` folder.
+    At the end of the process, the necessary files will be produced in the `build/prebuilt/release` or the `build/prebuilt/dev` folder.
 
 1. Once the build finished, set these environment variables:
 
@@ -430,9 +431,9 @@ While it is possible to interact with the Godot Engine directly from the main Re
     export REPLACE_EXISTING=true
     ```
 
-    These environment variables override the download logic of the download-prebuilt script of react-native-godot:
+    These environment variables override the download logic of the download-prebuilt script of `react-native-godot`:
 
-    * Use locally present files instead of the URLs specified in the package.json of react-native-godot.
+    * Use locally present files instead of the URLs specified in the `package.json` of `react-native-godot`.
     * Do not check the provided SHA-256 hash.
     * Force replacing the installed library, even if the same version was already installed.
 
@@ -445,8 +446,8 @@ While it is possible to interact with the Godot Engine directly from the main Re
 
     NOTE: An example usage of this script can be found in our example/update_deps.sh script.
 
-1. On Android, if using the development builds, in the react-native-godot/android/build.gradle the
-following line needs to be updated to include ``godot-dev`` as the artifactId:
+1. On Android, if using the development builds, in the `react-native-godot/android/build.gradle` the
+following line needs to be updated to include `godot-dev` as the artifactId:
 
     ```groovy
     api "com.migeran.libgodot:godot:${libGodotVersion}-SNAPSHOT"
@@ -462,7 +463,7 @@ Depending on the Xcode version, you might have to open these files separately in
 
 On Android a couple more steps will be required:
 
-* In the Android Studio Run/Debug configurations you also need to add a Symbol directory, where libgodot_android.so with the included debug symbols is located. One good place is: ``path/to/libgodot/godot/platform/android/java/lib/libs/dev/arm64-v8a``.
+* In the Android Studio Run/Debug configurations you also need to add a Symbol directory, where `libgodot_android.so` with the included debug symbols is located. One good place is: `path/to/libgodot/godot/platform/android/java/lib/libs/dev/arm64-v8a`.
 
 * Depending on the Android Studio version, you may have to include the Godot source tree under the Android Studio project to be able to set breakpoints. A way to do this is to create a symbolic link under the React Native Godot library as follows:
 
@@ -479,7 +480,7 @@ ln -s /path/to/libgodot/godot godot
 
 1. For remote debugging, you first need to build and install a development version of LibGodot as described above.
 
-1. Then add these 2 extra parameters to your RTNGodot.createInstance call:
+1. Then add these 2 extra parameters to your `RTNGodot.createInstance` call:
 
     ```typescript
     '--remote-debug',
@@ -506,7 +507,7 @@ ln -s /path/to/libgodot/godot godot
 
 1. Also enable 'Debug' -> 'Keep Debug Server Open'.
 
-1. Then add these 2 extra parameters to your RTNGodot.createInstance call:
+1. Then add these 2 extra parameters to your `RTNGodot.createInstance` call:
 
     ```typescript
     '--remote-debug',

--- a/README.md
+++ b/README.md
@@ -136,13 +136,13 @@ import { RTNGodot, RTNGodotView, runOnGodotThread } from "@borndotcom/react-nati
 
 ## Add the Godot View to your view, e.g.
 
-```typescript
+```tsx
 const App = () => {
-	return (
-        <View>
-            <RTNGodotView style={...}/>
-        </View>
-	)
+  return (
+    <View>
+      <RTNGodotView style={...}/>
+    </View>
+  );
 };
 ```
 
@@ -165,22 +165,23 @@ function initGodot() {
     console.log("Initializing Godot");
 
     if (Platform.OS === 'android') {
-        RTNGodot.createInstance(
-            ["--verbose", "--path",
-            "/main",
-            "--rendering-driver", "opengl3",
-            "--rendering-method", "gl_compatibility",
-            "--display-driver", "embedded"]
-        );  
+      RTNGodot.createInstance([
+        "--verbose",
+        "--path", "/main",
+        "--rendering-driver", "opengl3",
+        "--rendering-method", "gl_compatibility",
+        "--display-driver", "embedded"
+      ]);  
     } else {
-        RTNGodot.createInstance(
-            ["--verbose", "--main-pack",
-            FileSystem.bundleDirectory + "main.pck",
-            "--rendering-driver", "opengl3",
-            "--rendering-method", "gl_compatibility",
-            "--display-driver", "embedded"]
-        );  
+      RTNGodot.createInstance([
+        "--verbose",
+        "--main-pack", FileSystem.bundleDirectory + "main.pck",
+        "--rendering-driver", "opengl3",
+        "--rendering-method", "gl_compatibility",
+        "--display-driver", "embedded"
+      ]);  
     }
+  }
 }
 ```
 A couple of things to note here:
@@ -197,19 +198,18 @@ A couple of things to note here:
 
 ## Add the Godot initialization to the App component
 
-```typescript
+```tsx
 const App = () => {
-    useEffect(() => {
-      initGodot()
-      return () => {
-      }
-    }, [])
+  useEffect(() => {
+    initGodot()
+    return () => {};
+  }, []);
 
-    return (
-        <View>
-            <RTNGodotView style={...}/>
-        </View>
-	)
+  return (
+    <View>
+      <RTNGodotView style={...}/>
+    </View>
+  );
 };
 ```
 
@@ -351,18 +351,17 @@ class_name RNInterface
 
 func test_callable(c: Callable) -> void:
 	c.call("Hello from Godot")
-
 ```
 
 From TypeScript we may access it with the following code snippet:
 
 ```typescript
-let Godot = RTNGodot.API();
-var engine = Godot.Engine;
-var sceneTree = engine.get_main_loop();
-var root = sceneTree.get_root();
+const Godot = RTNGodot.API();
+const engine = Godot.Engine;
+const sceneTree = engine.get_main_loop();
+const root = sceneTree.get_root();
 
-var iface = root.find_child("RNInterface", true, false)
+const iface = root.find_child("RNInterface", true, false);
 
 iface.test_callable(function(s: string) {
   console.log("Received text from Godot: " + s)
@@ -379,7 +378,7 @@ Worklets are JavaScript functions designated with a 'worklet' keyword.
 
 ```typescript
 function worklet() {
-    'worklet'
+  'worklet'
 }
 ```
 


### PR DESCRIPTION
# Why

While going through the instruction and documentation in the README file I have spotted few minor things.

# How

Improve formatting, capitalization, code examples spacing and syntax in the README file content.

# Preview

* https://github.com/Simek/react-native-godot/tree/chore-readme-tweaks?tab=readme-ov-file