### PR TITLE
Remove source JS files from the published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "react-native": "js/index",
     "source": "js/index",
     "files": [
-        "js",
         "lib",
         "common",
         "android",


### PR DESCRIPTION
# Why

Spotted that `js` directory content is published within the npm package.

# How

Since `lib` contains transpiled source code for ESM/CJS and TS types there is no need to include source JS files in the package bundle.

> [!note]
> I have also spotted that Android `res` folder is included, which makes up for 1/3 of the package size. Usually for React Native packages most of the content in there is omittable, but will need to tests the setup and create test project locally to be 100% that this can be removed in Godot integration case.