### PR TITLE
Fix a line in README for consistency.

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,7 +449,7 @@ While it is possible to interact with the Godot Engine directly from the main Re
 following line needs to be updated to include ``godot-dev`` as the artifactId:
 
     ```groovy
-    api "com.migeran.libgodot:godot:${libGodotVersion}-SNAPSHOT"
+    api "com.migeran.libgodot:godot-debug:${libGodotVersion}-SNAPSHOT"
     ```
 
 ## Debug Native Godot code


### PR DESCRIPTION
Because in react-native-godot/android/build.gradle, line 452 now says:

api "com.migeran.libgodot:godot-debug:${libGodotVersion}-SNAPSHOT"